### PR TITLE
Compress Metadata in the outputfile

### DIFF
--- a/FastCdcFs.Net/FastCdcFsWriter.cs
+++ b/FastCdcFs.Net/FastCdcFsWriter.cs
@@ -108,8 +108,20 @@ public class FastCdcFsWriter(Options options)
         bw.Write("FastCdcFs"); // magic
         bw.Write(Version);
         bw.Write((byte)GetModes(options));
-        WriteDirectories(bw);
-        WriteFiles(bw);
+
+        // write metadata
+        using var memoryStream = new MemoryStream();
+        using var compressionStream = new ZstdSharp.CompressionStream(memoryStream, new Compressor(22));
+        using var bwMeta = new BinaryWriter(compressionStream, Encoding.UTF8, true);
+        WriteDirectories(bwMeta);
+        WriteFiles(bwMeta);
+        compressionStream.Flush();
+        var compressedMetaData = memoryStream.ToArray();
+
+        // write length of metadata and metadata
+        bw.Write((uint)compressedMetaData.LongLength);
+        bw.Write(compressedMetaData);
+
         WriteChunks(bw);
 
         Length = s.Position - pos;

--- a/FastCdcFs.Net/FastCdcFsWriter.cs
+++ b/FastCdcFs.Net/FastCdcFsWriter.cs
@@ -119,6 +119,8 @@ public class FastCdcFsWriter(Options options)
         var compressedMetaData = memoryStream.ToArray();
 
         // write length of metadata and metadata
+        if (compressedMetaData.LongLength > uint.MaxValue)
+            throw new InvalidOperationException("Compressed metadata exceeds 4GB and cannot be written as a 4-byte length.");
         bw.Write((uint)compressedMetaData.LongLength);
         bw.Write(compressedMetaData);
 


### PR DESCRIPTION
Add zstd compression to metadata, as it contains a lot of "00" bytes and filenames.